### PR TITLE
Add docs for building sonar-cxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It is part of **the [CBOMKit](https://github.com/PQCA/cbomkit) toolset**.
 > [!NOTE]
 > The plugin is designed in a modular way so that it can be extended to support additional languages and recognition rules to support more libraries.
 > - To add support for another language or cryptography library, see [*Extending the Sonar Cryptography Plugin to add support for another language or cryptography library*](./docs/LANGUAGE_SUPPORT.md)
+> - For community maintained C/C++ support, see [*Building SonarCXX locally*](./docs/C_LANGUAGE_SUPPORT.md)
 > - If you just want to know more about the syntax for writing new detection rules, see [*Writing new detection rules for the Sonar Cryptography Plugin*](./docs/DETECTION_RULE_STRUCTURE.md)
 
 ## Installation

--- a/docs/C_LANGUAGE_SUPPORT.md
+++ b/docs/C_LANGUAGE_SUPPORT.md
@@ -1,0 +1,35 @@
+# Building SonarCXX Locally
+
+The C/C++ parser used by the plugin (`sonar-cxx`) is not available on Maven Central. You must build the project locally and install it to your Maven repository before compiling this plugin.
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/SonarOpenCommunity/sonar-cxx.git
+   ```
+2. Build and install all modules:
+   ```bash
+   cd sonar-cxx
+   mvn clean install -DskipTests
+   ```
+   This installs the `sonar-cxx-plugin` artifacts into your local Maven repository (`~/.m2/repository`).
+
+3. Copy the generated plugin JAR to your SonarQube instance:
+   ```bash
+   cp sonar-cxx-plugin/target/sonar-cxx-plugin-*.jar $SONARQUBE_HOME/extensions/plugins/
+   ```
+
+# Compiling the Cryptography Plugin with C support
+
+After installing the SonarCXX artifacts, edit the root `pom.xml` to add the `c` module and add the module’s dependency on `org.sonarsource.sonarqube-plugins.cxx:sonar-cxx-plugin`.
+Then run:
+
+```bash
+mvn clean package
+```
+
+# Running on Amazon Linux (EC2)
+
+1. Install Java 17 and Maven using your package manager.
+2. Build SonarCXX as described above and copy the plugin JAR to the SonarQube `extensions/plugins` directory.
+3. Build this repository and copy the resulting `sonar-cryptography-plugin` JAR to the same directory.
+4. Start SonarQube and verify that both plugins appear in **Administration → Marketplace → Installed**.


### PR DESCRIPTION
## Summary
- document how to build sonar-cxx and use it for C/C++ support
- reference the new instructions in the README

## Testing
- `mvn -q test` *(fails: Could not resolve junit-bom from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_687a163319a88323a3c08ed15aee54b6