### PR TITLE
Fix CCheckRegistrar imports

### DIFF
--- a/c/src/main/java/com/ibm/plugin/CCheckRegistrar.java
+++ b/c/src/main/java/com/ibm/plugin/CCheckRegistrar.java
@@ -2,16 +2,25 @@ package com.ibm.plugin;
 
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.sonar.api.batch.rule.CheckRegistrar;
+import org.sonar.plugins.cxx.CustomCxxRulesDefinition;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @SonarLintSide
-
-public class CCheckRegistrar implements CheckRegistrar {
+public class CCheckRegistrar extends CustomCxxRulesDefinition {
     @Override
-    public void register(RegistrarContext registrarContext) {
-        registrarContext.registerClassesForRepository(
-                CScannerRuleDefinition.REPOSITORY_KEY, checkClasses(), testCheckClasses());
+    public String repositoryName() {
+        return CScannerRuleDefinition.REPOSITORY_NAME;
+    }
+
+    @Override
+    public String repositoryKey() {
+        return CScannerRuleDefinition.REPOSITORY_KEY;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class[] checkClasses() {
+        return CRuleList.getChecks().toArray(new Class[0]);
     }
 
     public static @Nonnull List<Class<?>> checkClasses() {


### PR DESCRIPTION
## Summary
- implement CCheckRegistrar using CustomCxxRulesDefinition to match the cxx API

## Testing
- `mvn -q -pl c -am package` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880c90672e48323880d7f857a83598e