### PR TITLE
Fix MethodMatcher instantiation in CxxLanguageSupport

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageSupport.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageSupport.java
@@ -74,7 +74,8 @@ public class CxxLanguageSupport implements ILanguageSupport<Object, Object, Obje
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("CXX matcher built for callee '{}'", name);
                 }
-                return new MethodMatcher<>(MethodMatcher.ANY, name);
+                return new MethodMatcher<>(
+                        new String[] {MethodMatcher.ANY}, new String[] {name});
             }
         }
         return null;


### PR DESCRIPTION
## Summary
- use string arrays when instantiating `MethodMatcher` to avoid generic inference failure in Cxx support

## Testing
- `mvn -q -pl engine -am test` *(fails: Non-resolvable import POM: org.junit:junit-bom due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b0b8173c08323be16a95cb5264549