### PR TITLE
Add trace logging across Python analysis path

### DIFF
--- a/common/src/main/java/com/ibm/util/CryptoTrace.java
+++ b/common/src/main/java/com/ibm/util/CryptoTrace.java
@@ -1,0 +1,38 @@
+package com.ibm.util;
+
+import java.time.Instant;
+
+public final class CryptoTrace {
+    private CryptoTrace() {}
+
+    public static boolean isEnabled() {
+        return Boolean.getBoolean("crypto.trace")
+                || "true".equalsIgnoreCase(System.getProperty("sonar.crypto.trace"));
+    }
+
+    public static String fmt(Object self, String method, String msg) {
+        return "[CRYPTO-TRACE] "
+                + Instant.now()
+                + " "
+                + Thread.currentThread().getName()
+                + " "
+                + self.getClass().getSimpleName()
+                + "#"
+                + method
+                + " "
+                + msg;
+    }
+
+    public static String fmt(Class<?> cls, String method, String msg) {
+        return "[CRYPTO-TRACE] "
+                + Instant.now()
+                + " "
+                + Thread.currentThread().getName()
+                + " "
+                + cls.getSimpleName()
+                + "#"
+                + method
+                + " "
+                + msg;
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageSupport.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageSupport.java
@@ -33,10 +33,13 @@ import com.ibm.engine.language.ILanguageSupport;
 import com.ibm.engine.language.ILanguageTranslation;
 import com.ibm.engine.language.IScanContext;
 import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.util.CryptoTrace;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
@@ -48,6 +51,7 @@ import org.sonar.plugins.python.api.tree.Tree;
 
 public class PythonLanguageSupport
         implements ILanguageSupport<PythonCheck, Tree, Symbol, PythonVisitorContext> {
+    private static final Logger LOG = Loggers.get(PythonLanguageSupport.class);
     @Nonnull private final Handler<PythonCheck, Tree, Symbol, PythonVisitorContext> handler;
 
     public PythonLanguageSupport() {
@@ -126,6 +130,14 @@ public class PythonLanguageSupport
                                 .map(param -> ANY)
                                 .toArray(String[]::new);
                 parameterTypeList = new LinkedList<>(Arrays.asList(parameters));
+            }
+
+            if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "createMethodMatcherBasedOn",
+                                "callee=" + name + " kind=" + methodDefinition.getKind()));
             }
 
             return new MethodMatcher<>(invocationObjectName, name, parameterTypeList);

--- a/output/src/main/java/com/ibm/output/cyclondx/CBOMOutputFile.java
+++ b/output/src/main/java/com/ibm/output/cyclondx/CBOMOutputFile.java
@@ -62,6 +62,7 @@ import com.ibm.output.cyclondx.builder.AlgorithmComponentBuilder;
 import com.ibm.output.cyclondx.builder.ProtocolComponentBuilder;
 import com.ibm.output.cyclondx.builder.RelatedCryptoMaterialComponentBuilder;
 import com.ibm.output.util.Utils;
+import com.ibm.util.CryptoTrace;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -90,11 +91,11 @@ import org.cyclonedx.model.OrganizationalEntity;
 import org.cyclonedx.model.Service;
 import org.cyclonedx.model.component.evidence.Occurrence;
 import org.cyclonedx.model.metadata.ToolInformation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public class CBOMOutputFile implements IOutputFile {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CBOMOutputFile.class);
+    private static final Logger LOG = Loggers.get(CBOMOutputFile.class);
     private static final Version schema = Version.VERSION_16;
 
     @Nonnull private final Map<String, Component> components;
@@ -339,10 +340,13 @@ public class CBOMOutputFile implements IOutputFile {
         try {
             final String bomString = bomGenerator.toJsonString();
             FileUtils.write(file, bomString, StandardCharsets.UTF_8, false);
+            if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+                LOG.trace(CryptoTrace.fmt(this, "saveTo", "path=" + file.getAbsolutePath()));
+            }
         } catch (IOException e) {
-            LOGGER.error("Could not write CBOM file: {}", e.getMessage());
+            LOG.error("Could not write CBOM file: {}", e.getMessage());
         } catch (GeneratorException e) {
-            LOGGER.error("Could not generate CBOM: {}", e.getMessage());
+            LOG.error("Could not generate CBOM: {}", e.getMessage());
         }
     }
 

--- a/output/src/main/java/com/ibm/output/statistics/ScanStatistics.java
+++ b/output/src/main/java/com/ibm/output/statistics/ScanStatistics.java
@@ -20,13 +20,17 @@
 package com.ibm.output.statistics;
 
 import com.ibm.mapper.model.INode;
+import com.ibm.util.CryptoTrace;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class ScanStatistics implements IStatistics {
+    private static final Logger LOG = Loggers.get(ScanStatistics.class);
     private final int numberOfDetectedAssets;
     @Nonnull private final Map<Class<? extends INode>, Long> numberOfAssetsPerType;
 
@@ -39,6 +43,13 @@ public final class ScanStatistics implements IStatistics {
 
     @Override
     public void print(@Nonnull Consumer<String> out) {
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            this,
+                            "print",
+                            "assets=" + numberOfDetectedAssets));
+        }
         out.accept("========== CBOM Statistics ==========");
         out.accept(String.format("%-33s: %s", "Detected Assets", numberOfDetectedAssets));
         for (Map.Entry<Class<? extends INode>, Long> entry : numberOfAssetsPerType.entrySet()) {

--- a/python/src/main/java/com/ibm/plugin/PythonAggregator.java
+++ b/python/src/main/java/com/ibm/plugin/PythonAggregator.java
@@ -23,16 +23,21 @@ import com.ibm.engine.language.ILanguageSupport;
 import com.ibm.engine.language.LanguageSupporter;
 import com.ibm.mapper.model.INode;
 import com.ibm.output.IAggregator;
+import com.ibm.util.CryptoTrace;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 
 public final class PythonAggregator implements IAggregator {
+
+    private static final Logger LOG = Loggers.get(PythonAggregator.class);
 
     private static ILanguageSupport<PythonCheck, Tree, Symbol, PythonVisitorContext>
             pythonLanguageSupport = LanguageSupporter.pythonLanguageSupporter();
@@ -56,6 +61,16 @@ public final class PythonAggregator implements IAggregator {
     public static void addNodes(@Nonnull List<INode> newNodes) {
         detectedNodes.addAll(newNodes);
         IAggregator.log(newNodes);
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            PythonAggregator.class,
+                            "addNodes",
+                            "added="
+                                    + newNodes.size()
+                                    + " total="
+                                    + detectedNodes.size()));
+        }
     }
 
     public static void reset() {

--- a/python/src/main/java/com/ibm/plugin/PythonCheckRegistrar.java
+++ b/python/src/main/java/com/ibm/plugin/PythonCheckRegistrar.java
@@ -19,13 +19,18 @@
  */
 package com.ibm.plugin;
 
+import com.ibm.util.CryptoTrace;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCustomRuleRepository;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @SonarLintSide
 public class PythonCheckRegistrar implements PythonCustomRuleRepository {
+    private static final Logger LOG = Loggers.get(PythonCheckRegistrar.class);
 
     @Override
     public String repositoryKey() {
@@ -34,8 +39,16 @@ public class PythonCheckRegistrar implements PythonCustomRuleRepository {
 
     @Override
     public List<Class<?>> checkClasses() {
-        // Creating a new list is necessary to return a type
-        // List<Class> from the type List<Class<? extends PythonCheck>>
-        return new ArrayList<>(PythonRuleList.getPythonChecks());
+        List<Class<?>> checks = new ArrayList<>(PythonRuleList.getPythonChecks());
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            String names =
+                    checks.stream().map(Class::getSimpleName).collect(Collectors.joining(","));
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            this,
+                            "checkClasses",
+                            "repo=" + repositoryKey() + " checks=" + names));
+        }
+        return checks;
     }
 }

--- a/python/src/main/java/com/ibm/plugin/PythonRuleList.java
+++ b/python/src/main/java/com/ibm/plugin/PythonRuleList.java
@@ -21,30 +21,64 @@ package com.ibm.plugin;
 
 import com.ibm.plugin.rules.PythonInventoryRule;
 import com.ibm.plugin.rules.PythonNoMD5UseRule;
+import com.ibm.util.CryptoTrace;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCheck;
 
 public final class PythonRuleList {
+
+    private static final Logger LOG = Loggers.get(PythonRuleList.class);
 
     private PythonRuleList() {}
 
     public static @Nonnull List<Class<?>> getChecks() {
         List<Class<? extends PythonCheck>> checks = new ArrayList<>();
-        checks.addAll(getPythonChecks());
-        checks.addAll(getPythonTestChecks());
-        return Collections.unmodifiableList(checks);
+        List<Class<? extends PythonCheck>> main = getPythonChecks();
+        List<Class<? extends PythonCheck>> test = getPythonTestChecks();
+        checks.addAll(main);
+        checks.addAll(test);
+        List<Class<?>> result = Collections.unmodifiableList(checks);
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            PythonRuleList.class,
+                            "getChecks",
+                            "size=" + result.size()));
+        }
+        return result;
     }
 
     /** These rules are going to target MAIN code only */
     public static @Nonnull List<Class<? extends PythonCheck>> getPythonChecks() {
-        return List.of(PythonInventoryRule.class, PythonNoMD5UseRule.class);
+        List<Class<? extends PythonCheck>> list =
+                List.of(PythonInventoryRule.class, PythonNoMD5UseRule.class);
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            String names = list.stream().map(Class::getSimpleName).collect(Collectors.joining(","));
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            PythonRuleList.class,
+                            "getPythonChecks",
+                            "size=" + list.size() + " classes=" + names));
+        }
+        return list;
     }
 
     /** These rules are going to target TEST code only */
     public static List<Class<? extends PythonCheck>> getPythonTestChecks() {
-        return List.of();
+        List<Class<? extends PythonCheck>> list = List.of();
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            PythonRuleList.class,
+                            "getPythonTestChecks",
+                            "size=" + list.size()));
+        }
+        return list;
     }
 }

--- a/python/src/main/java/com/ibm/plugin/PythonScannerRuleDefinition.java
+++ b/python/src/main/java/com/ibm/plugin/PythonScannerRuleDefinition.java
@@ -19,14 +19,18 @@
  */
 package com.ibm.plugin;
 
+import com.ibm.util.CryptoTrace;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonarsource.analyzer.commons.RuleMetadataLoader;
 
 public class PythonScannerRuleDefinition implements RulesDefinition {
+    private static final Logger LOG = Loggers.get(PythonScannerRuleDefinition.class);
     public static final String REPOSITORY_KEY = "sonar-python-crypto";
     public static final String REPOSITORY_NAME = "Sonar Cryptography";
 
@@ -43,6 +47,13 @@ public class PythonScannerRuleDefinition implements RulesDefinition {
 
     @Override
     public void define(Context context) {
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            this,
+                            "define",
+                            "start repo=" + REPOSITORY_KEY + " lang=py"));
+        }
         NewRepository repository =
                 context.createRepository(REPOSITORY_KEY, "py").setName(REPOSITORY_NAME);
 
@@ -52,6 +63,16 @@ public class PythonScannerRuleDefinition implements RulesDefinition {
         setTemplates(repository);
 
         repository.done();
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            this,
+                            "define",
+                            "end repo="
+                                    + REPOSITORY_KEY
+                                    + " lang=py rules="
+                                    + PythonRuleList.getChecks().size()));
+        }
     }
 
     private static void setTemplates(NewRepository repository) {

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
@@ -27,14 +27,18 @@ import com.ibm.output.statistics.ScanStatistics;
 import com.ibm.plugin.CAggregator;
 import com.ibm.plugin.JavaAggregator;
 import com.ibm.plugin.PythonAggregator;
+import com.ibm.util.CryptoTrace;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class ScannerManager {
+    private static final Logger LOG = Loggers.get(ScannerManager.class);
     private final IOutputFileFactory outputFileFactory;
 
     public ScannerManager(@Nullable IOutputFileFactory outputFileFactory) {
@@ -50,10 +54,20 @@ public final class ScannerManager {
 
     @Nonnull
     public IStatistics getStatistics() {
+        int py = PythonAggregator.getDetectedNodes().size();
+        int javaCount = JavaAggregator.getDetectedNodes().size();
+        int cCount = CAggregator.getDetectedNodes().size();
+        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+            LOG.trace(
+                    CryptoTrace.fmt(
+                            this,
+                            "getStatistics",
+                            "PY=" + py + " JAVA=" + javaCount + " C=" + cCount));
+        }
         return new ScanStatistics(
-                () -> getAggregatedNodes().size(), // numberOfDetectedAssetsSupplier
+                () -> getAggregatedNodes().size(),
                 () ->
-                        getAggregatedNodes().stream() // numberOfAssetsPerTypeSupplier
+                        getAggregatedNodes().stream()
                                 .collect(
                                         Collectors.groupingBy(
                                                 INode::getKind, Collectors.counting())));


### PR DESCRIPTION
## Summary
- add CryptoTrace utility for opt-in timestamped TRACE formatting
- instrument Python rule registration, detection engine, translation, and aggregation with guarded trace logs
- report CBOM generation details and per-language totals using Sonar logger

## Testing
- `mvn -q -pl common,engine,output,python,sonar-cryptography-plugin -am test` *(failed: Non-resolvable import POM: org.junit:junit-bom:pom:5.13.1)*

------
https://chatgpt.com/codex/tasks/task_e_689b28097cfc8323a558ce3c53586033