### PR TITLE
Remove obsolete Python visitor overrides

### DIFF
--- a/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
@@ -72,23 +72,6 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
     }
 
     @Override
-    public void init() {
-        super.init();
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "init",
-                            "kinds=" + nodesToVisit()));
-        }
-    }
-
-    @Override
-    public List<Tree.Kind> nodesToVisit() {
-        return List.of(Tree.Kind.CALL_EXPRESSION);
-    }
-
-    @Override
     public void visitCallExpression(@Nonnull CallExpression tree) {
         if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
             String file = new PythonScanContext(this.getContext()).getFilePath();


### PR DESCRIPTION
## Summary
- Update PythonBaseDetectionRule to align with latest Sonar Python API by removing deprecated init and nodesToVisit overrides

## Testing
- `mvn -q -pl python -am test` *(fails: Non-resolvable import POM for org.junit:junit-bom:pom:5.13.1 – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b2cd3adf08323a994c4fd889db86b