### PR TITLE
Fallback to debug logging when trace disabled

### DIFF
--- a/engine/src/main/java/com/ibm/engine/executive/DetectionExecutive.java
+++ b/engine/src/main/java/com/ibm/engine/executive/DetectionExecutive.java
@@ -56,15 +56,30 @@ public class DetectionExecutive<R, T, S, P>
     }
 
     public void start() {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "start",
-                            "rule="
-                                    + rootDetectionStore.getDetectionRule().bundle().getIdentifier()
-                                    + " file="
-                                    + rootDetectionStore.getScanContext().getFilePath()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "start",
+                                "rule="
+                                        + rootDetectionStore.getDetectionRule()
+                                                .bundle()
+                                                .getIdentifier()
+                                        + " file="
+                                        + rootDetectionStore.getScanContext().getFilePath()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "start",
+                                "rule="
+                                        + rootDetectionStore.getDetectionRule()
+                                                .bundle()
+                                                .getIdentifier()
+                                        + " file="
+                                        + rootDetectionStore.getScanContext().getFilePath()));
+            }
         }
         this.rootDetectionStore.analyse(tree);
     }
@@ -83,17 +98,30 @@ public class DetectionExecutive<R, T, S, P>
                 .forEach(
                         store -> {
                             final Finding<R, T, S, P> finding = new Finding<>(store);
-                            if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-                                LOG.trace(
-                                        CryptoTrace.fmt(
-                                                this,
-                                                "emitFinding",
-                                                "finding="
-                                                        + store.getStoreId()
-                                                        + " asset="
-                                                        + store.getDetectionValueContext()
-                                                                .getClass()
-                                                                .getSimpleName()));
+                            if (CryptoTrace.isEnabled()) {
+                                if (LOG.isTraceEnabled()) {
+                                    LOG.trace(
+                                            CryptoTrace.fmt(
+                                                    this,
+                                                    "emitFinding",
+                                                    "finding="
+                                                            + store.getStoreId()
+                                                            + " asset="
+                                                            + store.getDetectionValueContext()
+                                                                    .getClass()
+                                                                    .getSimpleName()));
+                                } else if (LOG.isDebugEnabled()) {
+                                    LOG.debug(
+                                            CryptoTrace.fmt(
+                                                    this,
+                                                    "emitFinding",
+                                                    "finding="
+                                                            + store.getStoreId()
+                                                            + " asset="
+                                                            + store.getDetectionValueContext()
+                                                                    .getClass()
+                                                                    .getSimpleName()));
+                                }
                             }
                             this.notify(finding);
                         });

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
@@ -63,15 +63,26 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
 
     @Override
     public void run(@Nonnull TraceSymbol<Symbol> traceSymbol, @Nonnull Tree tree) {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "run",
-                            "file="
-                                    + detectionStore.getScanContext().getFilePath()
-                                    + " kind="
-                                    + tree.getKind()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "run",
+                                "file="
+                                        + detectionStore.getScanContext().getFilePath()
+                                        + " kind="
+                                        + tree.getKind()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "run",
+                                "file="
+                                        + detectionStore.getScanContext().getFilePath()
+                                        + " kind="
+                                        + tree.getKind()));
+            }
         }
         if (tree instanceof CallExpression callExpressionTree) {
             handler.addCallToCallStack(callExpressionTree, detectionStore.getScanContext());
@@ -88,7 +99,7 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                             .match(callExpressionTree, handler.getLanguageSupport().translation());
             if (matched) {
                 this.analyseExpression(traceSymbol, callExpressionTree);
-                if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+                if (CryptoTrace.isEnabled()) {
                     String asset =
                             detectionStore
                                     .getDetectionValueContext()
@@ -99,29 +110,55 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                                     .findFirst()
                                     .map(v -> v.asString())
                                     .orElse("");
-                    LOG.trace(
-                            CryptoTrace.fmt(
-                                    this,
-                                    "run",
-                                    "MATCH rule="
-                                            + detectionStore
-                                                    .getDetectionRule()
-                                                    .bundle()
-                                                    .getIdentifier()
-                                            + " callee="
-                                            + callee
-                                            + " asset="
-                                            + asset
-                                            + " alg="
-                                            + alg));
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace(
+                                CryptoTrace.fmt(
+                                        this,
+                                        "run",
+                                        "MATCH rule="
+                                                + detectionStore
+                                                        .getDetectionRule()
+                                                        .bundle()
+                                                        .getIdentifier()
+                                                + " callee="
+                                                + callee
+                                                + " asset="
+                                                + asset
+                                                + " alg="
+                                                + alg));
+                    } else if (LOG.isDebugEnabled()) {
+                        LOG.debug(
+                                CryptoTrace.fmt(
+                                        this,
+                                        "run",
+                                        "MATCH rule="
+                                                + detectionStore
+                                                        .getDetectionRule()
+                                                        .bundle()
+                                                        .getIdentifier()
+                                                + " callee="
+                                                + callee
+                                                + " asset="
+                                                + asset
+                                                + " alg="
+                                                + alg));
+                    }
                 }
             } else {
-                if (LOG.isTraceEnabled()
-                        && CryptoTrace.isEnabled()
-                        && noMatchLogged.add(callee)) {
-                    LOG.trace(
-                            CryptoTrace.fmt(
-                                    this, "run", "NO-MATCH callee=" + callee));
+                if (CryptoTrace.isEnabled()) {
+                    if (LOG.isTraceEnabled()) {
+                        if (noMatchLogged.add(callee)) {
+                            LOG.trace(
+                                    CryptoTrace.fmt(
+                                            this, "run", "NO-MATCH callee=" + callee));
+                        }
+                    } else if (LOG.isDebugEnabled()) {
+                        if (noMatchLogged.add(callee)) {
+                            LOG.debug(
+                                    CryptoTrace.fmt(
+                                            this, "run", "NO-MATCH callee=" + callee));
+                        }
+                    }
                 }
             }
         }

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageSupport.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageSupport.java
@@ -132,12 +132,20 @@ public class PythonLanguageSupport
                 parameterTypeList = new LinkedList<>(Arrays.asList(parameters));
             }
 
-            if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-                LOG.trace(
-                        CryptoTrace.fmt(
-                                this,
-                                "createMethodMatcherBasedOn",
-                                "callee=" + name + " kind=" + methodDefinition.getKind()));
+            if (CryptoTrace.isEnabled()) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace(
+                            CryptoTrace.fmt(
+                                    this,
+                                    "createMethodMatcherBasedOn",
+                                    "callee=" + name + " kind=" + methodDefinition.getKind()));
+                } else if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            CryptoTrace.fmt(
+                                    this,
+                                    "createMethodMatcherBasedOn",
+                                    "callee=" + name + " kind=" + methodDefinition.getKind()));
+                }
             }
 
             return new MethodMatcher<>(invocationObjectName, name, parameterTypeList);

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageTranslation.java
@@ -55,12 +55,20 @@ public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
                 res = Optional.of(nameTree.name());
             }
         }
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "getMethodName",
-                            "name=" + res.orElse("<empty>")));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "getMethodName",
+                                "name=" + res.orElse("<empty>")));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "getMethodName",
+                                "name=" + res.orElse("<empty>")));
+            }
         }
         return res;
     }
@@ -81,12 +89,20 @@ public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
                 res = PythonSemantic.resolveTreeType(functionName);
             }
         }
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "getInvokedObjectTypeString",
-                            "type=" + res.map(Object::toString).orElse("<empty>")));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "getInvokedObjectTypeString",
+                                "type=" + res.map(Object::toString).orElse("<empty>")));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "getInvokedObjectTypeString",
+                                "type=" + res.map(Object::toString).orElse("<empty>")));
+            }
         }
         return res;
     }
@@ -97,12 +113,20 @@ public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
         // TODO: This does not take the subscriptionIndex into account, so it will return an IType
         // accepting the type of all
         Optional<IType> res = PythonSemantic.resolveTreeType(methodInvocation);
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "getMethodReturnTypeString",
-                            "type=" + res.map(Object::toString).orElse("<empty>")));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "getMethodReturnTypeString",
+                                "type=" + res.map(Object::toString).orElse("<empty>")));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "getMethodReturnTypeString",
+                                "type=" + res.map(Object::toString).orElse("<empty>")));
+            }
         }
         return res;
     }
@@ -126,13 +150,21 @@ public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
                                 .toList();
             }
         }
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+        if (CryptoTrace.isEnabled()) {
             String types = res.stream().map(Object::toString).collect(Collectors.joining(","));
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "getMethodParameterTypes",
-                            "types=" + types));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "getMethodParameterTypes",
+                                "types=" + types));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "getMethodParameterTypes",
+                                "types=" + types));
+            }
         }
         return res;
     }
@@ -144,12 +176,20 @@ public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
         if (name instanceof Name nameTree) {
             res = Optional.of(nameTree.name());
         }
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "resolveIdentifierAsString",
-                            "id=" + res.orElse("<empty>")));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "resolveIdentifierAsString",
+                                "id=" + res.orElse("<empty>")));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "resolveIdentifierAsString",
+                                "id=" + res.orElse("<empty>")));
+            }
         }
         return res;
     }

--- a/output/src/main/java/com/ibm/output/cyclondx/CBOMOutputFile.java
+++ b/output/src/main/java/com/ibm/output/cyclondx/CBOMOutputFile.java
@@ -340,8 +340,16 @@ public class CBOMOutputFile implements IOutputFile {
         try {
             final String bomString = bomGenerator.toJsonString();
             FileUtils.write(file, bomString, StandardCharsets.UTF_8, false);
-            if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-                LOG.trace(CryptoTrace.fmt(this, "saveTo", "path=" + file.getAbsolutePath()));
+            if (CryptoTrace.isEnabled()) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace(
+                            CryptoTrace.fmt(
+                                    this, "saveTo", "path=" + file.getAbsolutePath()));
+                } else if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            CryptoTrace.fmt(
+                                    this, "saveTo", "path=" + file.getAbsolutePath()));
+                }
             }
         } catch (IOException e) {
             LOG.error("Could not write CBOM file: {}", e.getMessage());

--- a/output/src/main/java/com/ibm/output/statistics/ScanStatistics.java
+++ b/output/src/main/java/com/ibm/output/statistics/ScanStatistics.java
@@ -43,12 +43,20 @@ public final class ScanStatistics implements IStatistics {
 
     @Override
     public void print(@Nonnull Consumer<String> out) {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "print",
-                            "assets=" + numberOfDetectedAssets));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "print",
+                                "assets=" + numberOfDetectedAssets));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "print",
+                                "assets=" + numberOfDetectedAssets));
+            }
         }
         out.accept("========== CBOM Statistics ==========");
         out.accept(String.format("%-33s: %s", "Detected Assets", numberOfDetectedAssets));

--- a/python/src/main/java/com/ibm/plugin/PythonAggregator.java
+++ b/python/src/main/java/com/ibm/plugin/PythonAggregator.java
@@ -61,15 +61,26 @@ public final class PythonAggregator implements IAggregator {
     public static void addNodes(@Nonnull List<INode> newNodes) {
         detectedNodes.addAll(newNodes);
         IAggregator.log(newNodes);
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            PythonAggregator.class,
-                            "addNodes",
-                            "added="
-                                    + newNodes.size()
-                                    + " total="
-                                    + detectedNodes.size()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                PythonAggregator.class,
+                                "addNodes",
+                                "added="
+                                        + newNodes.size()
+                                        + " total="
+                                        + detectedNodes.size()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                PythonAggregator.class,
+                                "addNodes",
+                                "added="
+                                        + newNodes.size()
+                                        + " total="
+                                        + detectedNodes.size()));
+            }
         }
     }
 

--- a/python/src/main/java/com/ibm/plugin/PythonCheckRegistrar.java
+++ b/python/src/main/java/com/ibm/plugin/PythonCheckRegistrar.java
@@ -40,14 +40,22 @@ public class PythonCheckRegistrar implements PythonCustomRuleRepository {
     @Override
     public List<Class<?>> checkClasses() {
         List<Class<?>> checks = new ArrayList<>(PythonRuleList.getPythonChecks());
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+        if (CryptoTrace.isEnabled()) {
             String names =
                     checks.stream().map(Class::getSimpleName).collect(Collectors.joining(","));
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "checkClasses",
-                            "repo=" + repositoryKey() + " checks=" + names));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "checkClasses",
+                                "repo=" + repositoryKey() + " checks=" + names));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "checkClasses",
+                                "repo=" + repositoryKey() + " checks=" + names));
+            }
         }
         return checks;
     }

--- a/python/src/main/java/com/ibm/plugin/PythonRuleList.java
+++ b/python/src/main/java/com/ibm/plugin/PythonRuleList.java
@@ -44,12 +44,20 @@ public final class PythonRuleList {
         checks.addAll(main);
         checks.addAll(test);
         List<Class<?>> result = Collections.unmodifiableList(checks);
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            PythonRuleList.class,
-                            "getChecks",
-                            "size=" + result.size()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                PythonRuleList.class,
+                                "getChecks",
+                                "size=" + result.size()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                PythonRuleList.class,
+                                "getChecks",
+                                "size=" + result.size()));
+            }
         }
         return result;
     }
@@ -58,13 +66,21 @@ public final class PythonRuleList {
     public static @Nonnull List<Class<? extends PythonCheck>> getPythonChecks() {
         List<Class<? extends PythonCheck>> list =
                 List.of(PythonInventoryRule.class, PythonNoMD5UseRule.class);
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+        if (CryptoTrace.isEnabled()) {
             String names = list.stream().map(Class::getSimpleName).collect(Collectors.joining(","));
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            PythonRuleList.class,
-                            "getPythonChecks",
-                            "size=" + list.size() + " classes=" + names));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                PythonRuleList.class,
+                                "getPythonChecks",
+                                "size=" + list.size() + " classes=" + names));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                PythonRuleList.class,
+                                "getPythonChecks",
+                                "size=" + list.size() + " classes=" + names));
+            }
         }
         return list;
     }
@@ -72,12 +88,20 @@ public final class PythonRuleList {
     /** These rules are going to target TEST code only */
     public static List<Class<? extends PythonCheck>> getPythonTestChecks() {
         List<Class<? extends PythonCheck>> list = List.of();
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            PythonRuleList.class,
-                            "getPythonTestChecks",
-                            "size=" + list.size()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                PythonRuleList.class,
+                                "getPythonTestChecks",
+                                "size=" + list.size()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                PythonRuleList.class,
+                                "getPythonTestChecks",
+                                "size=" + list.size()));
+            }
         }
         return list;
     }

--- a/python/src/main/java/com/ibm/plugin/PythonScannerRuleDefinition.java
+++ b/python/src/main/java/com/ibm/plugin/PythonScannerRuleDefinition.java
@@ -47,12 +47,20 @@ public class PythonScannerRuleDefinition implements RulesDefinition {
 
     @Override
     public void define(Context context) {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "define",
-                            "start repo=" + REPOSITORY_KEY + " lang=py"));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "define",
+                                "start repo=" + REPOSITORY_KEY + " lang=py"));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "define",
+                                "start repo=" + REPOSITORY_KEY + " lang=py"));
+            }
         }
         NewRepository repository =
                 context.createRepository(REPOSITORY_KEY, "py").setName(REPOSITORY_NAME);
@@ -63,15 +71,26 @@ public class PythonScannerRuleDefinition implements RulesDefinition {
         setTemplates(repository);
 
         repository.done();
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "define",
-                            "end repo="
-                                    + REPOSITORY_KEY
-                                    + " lang=py rules="
-                                    + PythonRuleList.getChecks().size()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "define",
+                                "end repo="
+                                        + REPOSITORY_KEY
+                                        + " lang=py rules="
+                                        + PythonRuleList.getChecks().size()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "define",
+                                "end repo="
+                                        + REPOSITORY_KEY
+                                        + " lang=py rules="
+                                        + PythonRuleList.getChecks().size()));
+            }
         }
     }
 

--- a/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
@@ -73,32 +73,53 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
 
     @Override
     public void visitCallExpression(@Nonnull CallExpression tree) {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+        if (CryptoTrace.isEnabled()) {
             String file = new PythonScanContext(this.getContext()).getFilePath();
             int line = tree.firstToken().line();
             String callee =
                     Optional.ofNullable(tree.calleeSymbol())
                             .map(Symbol::name)
                             .orElse("<unknown>");
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "visitCallExpression",
-                            "file=" + file + ":" + line + " callee=" + callee));
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "visitCallExpression",
-                            "running " + detectionRules.size() + " detection rules"));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "visitCallExpression",
+                                "file=" + file + ":" + line + " callee=" + callee));
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "visitCallExpression",
+                                "running " + detectionRules.size() + " detection rules"));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "visitCallExpression",
+                                "file=" + file + ":" + line + " callee=" + callee));
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "visitCallExpression",
+                                "running " + detectionRules.size() + " detection rules"));
+            }
         }
         detectionRules.forEach(
                 rule -> {
-                    if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-                        LOG.trace(
-                                CryptoTrace.fmt(
-                                        this,
-                                        "visitCallExpression",
-                                        "rule=" + rule.bundle().getIdentifier()));
+                    if (CryptoTrace.isEnabled()) {
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace(
+                                    CryptoTrace.fmt(
+                                            this,
+                                            "visitCallExpression",
+                                            "rule=" + rule.bundle().getIdentifier()));
+                        } else if (LOG.isDebugEnabled()) {
+                            LOG.debug(
+                                    CryptoTrace.fmt(
+                                            this,
+                                            "visitCallExpression",
+                                            "rule=" + rule.bundle().getIdentifier()));
+                        }
                     }
                     DetectionExecutive<PythonCheck, Tree, Symbol, PythonVisitorContext>
                             detectionExecutive =
@@ -121,15 +142,26 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
     @Override
     public void update(@Nonnull Finding<PythonCheck, Tree, Symbol, PythonVisitorContext> finding) {
         List<INode> nodes = pythonTranslationProcess.initiate(finding.detectionStore());
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            nodes.forEach(
-                    n ->
-                            LOG.trace(
-                                    CryptoTrace.fmt(
-                                            this,
-                                            "update",
-                                            "asset="
-                                                    + n.getKind().getSimpleName())));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                nodes.forEach(
+                        n ->
+                                LOG.trace(
+                                        CryptoTrace.fmt(
+                                                this,
+                                                "update",
+                                                "asset="
+                                                        + n.getKind().getSimpleName())));
+            } else if (LOG.isDebugEnabled()) {
+                nodes.forEach(
+                        n ->
+                                LOG.debug(
+                                        CryptoTrace.fmt(
+                                                this,
+                                                "update",
+                                                "asset="
+                                                        + n.getKind().getSimpleName())));
+            }
         }
         if (isInventory) {
             PythonAggregator.addNodes(nodes);

--- a/python/src/main/java/com/ibm/plugin/translation/PythonTranslationProcess.java
+++ b/python/src/main/java/com/ibm/plugin/translation/PythonTranslationProcess.java
@@ -53,12 +53,20 @@ public final class PythonTranslationProcess
             @Nonnull
                     DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext>
                             rootDetectionStore) {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "initiate",
-                            "finding=" + rootDetectionStore.getStoreId()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "initiate",
+                                "finding=" + rootDetectionStore.getStoreId()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "initiate",
+                                "finding=" + rootDetectionStore.getStoreId()));
+            }
         }
         final PythonTranslator pythonTranslator = new PythonTranslator();
         final List<INode> translatedValues = pythonTranslator.translate(rootDetectionStore);
@@ -71,12 +79,20 @@ public final class PythonTranslationProcess
         final List<INode> enrichedValues = Enricher.enrich(reorganizedValues).stream().toList();
         Utils.printNodeTree("  enriched  ", enrichedValues);
 
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "initiate",
-                            "nodes=" + enrichedValues.size()));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "initiate",
+                                "nodes=" + enrichedValues.size()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "initiate",
+                                "nodes=" + enrichedValues.size()));
+            }
         }
         return Collections.unmodifiableCollection(enrichedValues).stream().toList();
     }

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
@@ -42,8 +42,12 @@ public class OutputFileJob implements PostJob {
 
     @Override
     public void execute(@Nonnull PostJobContext postJobContext) {
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(CryptoTrace.fmt(this, "execute", "start"));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(CryptoTrace.fmt(this, "execute", "start"));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(CryptoTrace.fmt(this, "execute", "start"));
+            }
         }
         final String cbomFilename =
                 postJobContext
@@ -53,22 +57,37 @@ public class OutputFileJob implements PostJob {
         ScannerManager scannerManager = new ScannerManager(new CBOMOutputFileFactory());
         final File cbom = new File(cbomFilename + ".json");
         scannerManager.getOutputFile().saveTo(cbom);
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
+        if (CryptoTrace.isEnabled()) {
             int py = PythonAggregator.getDetectedNodes().size();
             int javaCount = JavaAggregator.getDetectedNodes().size();
             int cCount = CAggregator.getDetectedNodes().size();
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "execute",
-                            "end cbom="
-                                    + cbom.getAbsolutePath()
-                                    + " PY="
-                                    + py
-                                    + " JAVA="
-                                    + javaCount
-                                    + " C="
-                                    + cCount));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "execute",
+                                "end cbom="
+                                        + cbom.getAbsolutePath()
+                                        + " PY="
+                                        + py
+                                        + " JAVA="
+                                        + javaCount
+                                        + " C="
+                                        + cCount));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "execute",
+                                "end cbom="
+                                        + cbom.getAbsolutePath()
+                                        + " PY="
+                                        + py
+                                        + " JAVA="
+                                        + javaCount
+                                        + " C="
+                                        + cCount));
+            }
         }
         LOG.info("CBOM was successfully generated '{}'.", cbom.getAbsolutePath());
         scannerManager.getStatistics().print(LOG::info);

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
@@ -57,12 +57,20 @@ public final class ScannerManager {
         int py = PythonAggregator.getDetectedNodes().size();
         int javaCount = JavaAggregator.getDetectedNodes().size();
         int cCount = CAggregator.getDetectedNodes().size();
-        if (LOG.isTraceEnabled() && CryptoTrace.isEnabled()) {
-            LOG.trace(
-                    CryptoTrace.fmt(
-                            this,
-                            "getStatistics",
-                            "PY=" + py + " JAVA=" + javaCount + " C=" + cCount));
+        if (CryptoTrace.isEnabled()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        CryptoTrace.fmt(
+                                this,
+                                "getStatistics",
+                                "PY=" + py + " JAVA=" + javaCount + " C=" + cCount));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        CryptoTrace.fmt(
+                                this,
+                                "getStatistics",
+                                "PY=" + py + " JAVA=" + javaCount + " C=" + cCount));
+            }
         }
         return new ScanStatistics(
                 () -> getAggregatedNodes().size(),


### PR DESCRIPTION
## Summary
- ensure CryptoTrace logs fall back to DEBUG when TRACE is disabled
- propagate new logging guard across modules

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c39424d08832398c434ef750e2cb8