### PR TITLE
feat(python): add scan-time logging

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageTranslation.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Argument;
 import org.sonar.plugins.python.api.tree.CallExpression;
@@ -36,22 +38,26 @@ import org.sonar.plugins.python.api.tree.Tree;
 
 public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
 
+    private static final Logger LOG = Loggers.get(PythonLanguageTranslation.class);
+
     @Nonnull
     @Override
     public Optional<String> getMethodName(
             @Nonnull MatchContext matchContext, @Nonnull Tree methodInvocation) {
+        Optional<String> result = Optional.empty();
         if (methodInvocation instanceof CallExpression callExpression) {
             // We use "name" and not "fullyQualifiedName" to make it like in the Java implementation
             Symbol methodInvocationSymbol = callExpression.calleeSymbol();
             if (methodInvocationSymbol != null) {
-                return Optional.of(methodInvocationSymbol.name());
+                result = Optional.of(methodInvocationSymbol.name());
             } else if (callExpression.callee()
                     instanceof Name nameTree) { // Rare case when the symbol is not defined,
                 // sometimes for imported classes
-                return Optional.of(nameTree.name());
+                result = Optional.of(nameTree.name());
             }
         }
-        return Optional.empty();
+        LOG.info("PY translation: method name = {}", result.orElse("<empty>"));
+        return result;
     }
 
     @Nonnull

--- a/python/src/main/java/com/ibm/plugin/PythonAggregator.java
+++ b/python/src/main/java/com/ibm/plugin/PythonAggregator.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
@@ -37,6 +39,8 @@ public final class PythonAggregator implements IAggregator {
     private static ILanguageSupport<PythonCheck, Tree, Symbol, PythonVisitorContext>
             pythonLanguageSupport = LanguageSupporter.pythonLanguageSupporter();
     private static List<INode> detectedNodes = new ArrayList<>();
+
+    private static final Logger LOG = Loggers.get(PythonAggregator.class);
 
     private PythonAggregator() {
         // nothing
@@ -56,6 +60,8 @@ public final class PythonAggregator implements IAggregator {
     public static void addNodes(@Nonnull List<INode> newNodes) {
         detectedNodes.addAll(newNodes);
         IAggregator.log(newNodes);
+        LOG.info(
+                "PY aggregate: added={} total={}", newNodes.size(), detectedNodes.size());
     }
 
     public static void reset() {

--- a/python/src/main/java/com/ibm/plugin/PythonCheckRegistrar.java
+++ b/python/src/main/java/com/ibm/plugin/PythonCheckRegistrar.java
@@ -21,11 +21,16 @@ package com.ibm.plugin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCustomRuleRepository;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @SonarLintSide
 public class PythonCheckRegistrar implements PythonCustomRuleRepository {
+
+    private static final Logger LOG = Loggers.get(PythonCheckRegistrar.class);
 
     @Override
     public String repositoryKey() {
@@ -36,6 +41,13 @@ public class PythonCheckRegistrar implements PythonCustomRuleRepository {
     public List<Class<?>> checkClasses() {
         // Creating a new list is necessary to return a type
         // List<Class> from the type List<Class<? extends PythonCheck>>
-        return new ArrayList<>(PythonRuleList.getPythonChecks());
+        List<Class<?>> checks = new ArrayList<>(PythonRuleList.getPythonChecks());
+        LOG.info(
+                "Registering PY checks for repo '{}' : {}",
+                PythonScannerRuleDefinition.REPOSITORY_KEY,
+                checks.stream()
+                        .map(Class::getSimpleName)
+                        .collect(Collectors.joining(", ")));
+        return checks;
     }
 }

--- a/python/src/main/java/com/ibm/plugin/PythonRuleList.java
+++ b/python/src/main/java/com/ibm/plugin/PythonRuleList.java
@@ -24,27 +24,54 @@ import com.ibm.plugin.rules.PythonNoMD5UseRule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCheck;
 
 public final class PythonRuleList {
 
     private PythonRuleList() {}
 
+    private static final Logger LOG = Loggers.get(PythonRuleList.class);
+
     public static @Nonnull List<Class<?>> getChecks() {
         List<Class<? extends PythonCheck>> checks = new ArrayList<>();
         checks.addAll(getPythonChecks());
         checks.addAll(getPythonTestChecks());
-        return Collections.unmodifiableList(checks);
+        List<Class<?>> result = Collections.unmodifiableList(checks);
+        LOG.info(
+                "PY rule list -> {} checks: {}",
+                result.size(),
+                result.stream()
+                        .map(Class::getSimpleName)
+                        .collect(Collectors.joining(", ")));
+        return result;
     }
 
     /** These rules are going to target MAIN code only */
     public static @Nonnull List<Class<? extends PythonCheck>> getPythonChecks() {
-        return List.of(PythonInventoryRule.class, PythonNoMD5UseRule.class);
+        List<Class<? extends PythonCheck>> list =
+                List.of(PythonInventoryRule.class, PythonNoMD5UseRule.class);
+        LOG.info(
+                "PY rule list -> {} checks: {}",
+                list.size(),
+                list.stream()
+                        .map(Class::getSimpleName)
+                        .collect(Collectors.joining(", ")));
+        return list;
     }
 
     /** These rules are going to target TEST code only */
     public static List<Class<? extends PythonCheck>> getPythonTestChecks() {
-        return List.of();
+        List<Class<? extends PythonCheck>> list = List.of();
+        LOG.info(
+                "PY rule list -> {} checks: {}",
+                list.size(),
+                list.stream()
+                        .map(Class::getSimpleName)
+                        .collect(Collectors.joining(", ")));
+        return list;
     }
 }

--- a/python/src/main/java/com/ibm/plugin/PythonScannerRuleDefinition.java
+++ b/python/src/main/java/com/ibm/plugin/PythonScannerRuleDefinition.java
@@ -22,8 +22,12 @@ package com.ibm.plugin;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinition.NewRule;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonarsource.analyzer.commons.RuleMetadataLoader;
 
 public class PythonScannerRuleDefinition implements RulesDefinition {
@@ -36,6 +40,8 @@ public class PythonScannerRuleDefinition implements RulesDefinition {
     private static final String RESOURCE_BASE_PATH = "/org/sonar/l10n/python/rules/python";
 
     private final SonarRuntime sonarRuntime;
+
+    private static final Logger LOG = Loggers.get(PythonScannerRuleDefinition.class);
 
     public PythonScannerRuleDefinition(SonarRuntime sonarRuntime) {
         this.sonarRuntime = sonarRuntime;
@@ -52,6 +58,13 @@ public class PythonScannerRuleDefinition implements RulesDefinition {
         setTemplates(repository);
 
         repository.done();
+
+        LOG.info(
+                "Registered PY repository '{}' with rules {}",
+                REPOSITORY_KEY,
+                repository.rules().stream()
+                        .map(NewRule::key)
+                        .collect(Collectors.toList()));
     }
 
     private static void setTemplates(NewRepository repository) {

--- a/python/src/main/java/com/ibm/plugin/rules/PythonInventoryRule.java
+++ b/python/src/main/java/com/ibm/plugin/rules/PythonInventoryRule.java
@@ -28,6 +28,8 @@ import com.ibm.rules.InventoryRule;
 import com.ibm.rules.issue.Issue;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.check.Rule;
 import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.plugins.python.api.tree.Tree;
@@ -35,8 +37,14 @@ import org.sonar.plugins.python.api.tree.Tree;
 @Rule(key = "Inventory")
 public class PythonInventoryRule extends PythonBaseDetectionRule {
 
+    private static final Logger LOG = Loggers.get(PythonInventoryRule.class);
+
     public PythonInventoryRule() {
         super(true, PythonDetectionRules.rules(), PythonReorganizerRules.rules());
+        LOG.info(
+                "PY visitor '{}' initialized; subscribing to node kinds: {}",
+                "Inventory",
+                "CALL_EXPRESSION");
     }
 
     @VisibleForTesting

--- a/python/src/main/java/com/ibm/plugin/translation/PythonTranslationProcess.java
+++ b/python/src/main/java/com/ibm/plugin/translation/PythonTranslationProcess.java
@@ -30,6 +30,8 @@ import com.ibm.plugin.translation.translator.PythonTranslator;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
@@ -37,6 +39,8 @@ import org.sonar.plugins.python.api.tree.Tree;
 
 public final class PythonTranslationProcess
         extends ITranslationProcess<PythonCheck, Tree, Symbol, PythonVisitorContext> {
+
+    private static final Logger LOG = Loggers.get(PythonTranslationProcess.class);
 
     public PythonTranslationProcess(@Nonnull List<IReorganizerRule> reorganizerRules) {
         super(reorganizerRules);
@@ -48,6 +52,7 @@ public final class PythonTranslationProcess
             @Nonnull
                     DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext>
                             rootDetectionStore) {
+        LOG.info("PY translate: finding id={} start", rootDetectionStore.getStoreId());
         // 1. Translate
         final PythonTranslator pythonTranslator = new PythonTranslator();
         final List<INode> translatedValues = pythonTranslator.translate(rootDetectionStore);
@@ -61,7 +66,12 @@ public final class PythonTranslationProcess
         // 3. Enrich
         final List<INode> enrichedValues = Enricher.enrich(reorganizedValues).stream().toList();
         Utils.printNodeTree("  enriched  ", enrichedValues);
-
-        return Collections.unmodifiableCollection(enrichedValues).stream().toList();
+        List<INode> result =
+                Collections.unmodifiableCollection(enrichedValues).stream().toList();
+        LOG.info(
+                "PY translate: finding id={} produced {} nodes",
+                rootDetectionStore.getStoreId(),
+                result.size());
+        return result;
     }
 }

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
@@ -19,17 +19,20 @@
  */
 package com.ibm.plugin;
 
+import com.ibm.plugin.CAggregator;
+import com.ibm.plugin.JavaAggregator;
+import com.ibm.plugin.PythonAggregator;
 import com.ibm.output.cyclondx.CBOMOutputFileFactory;
 import java.io.File;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.postjob.PostJob;
 import org.sonar.api.batch.postjob.PostJobContext;
 import org.sonar.api.batch.postjob.PostJobDescriptor;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public class OutputFileJob implements PostJob {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OutputFileJob.class);
+    private static final Logger LOG = Loggers.get(OutputFileJob.class);
 
     @Override
     public void describe(PostJobDescriptor postJobDescriptor) {
@@ -44,10 +47,15 @@ public class OutputFileJob implements PostJob {
                         .get(Constants.CBOM_OUTPUT_NAME)
                         .orElse(Constants.CBOM_OUTPUT_NAME_DEFAULT);
         ScannerManager scannerManager = new ScannerManager(new CBOMOutputFileFactory());
+        LOG.info(
+                "CBOM write: PY={} JAVA={} C={}",
+                PythonAggregator.getDetectedNodes().size(),
+                JavaAggregator.getDetectedNodes().size(),
+                CAggregator.getDetectedNodes().size());
         final File cbom = new File(cbomFilename + ".json");
         scannerManager.getOutputFile().saveTo(cbom);
-        LOGGER.info("CBOM was successfully generated '{}'.", cbom.getAbsolutePath());
-        scannerManager.getStatistics().print(LOGGER::info);
+        LOG.info("CBOM was successfully generated '{}'.", cbom.getAbsolutePath());
+        scannerManager.getStatistics().print(LOG::info);
         scannerManager.reset();
     }
 }

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
@@ -33,9 +33,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class ScannerManager {
     private final IOutputFileFactory outputFileFactory;
+
+    private static final Logger LOG = Loggers.get(ScannerManager.class);
 
     public ScannerManager(@Nullable IOutputFileFactory outputFileFactory) {
         this.outputFileFactory = outputFileFactory;
@@ -65,10 +69,18 @@ public final class ScannerManager {
 
     @Nonnull
     private List<INode> getAggregatedNodes() {
+        List<INode> javaNodes = JavaAggregator.getDetectedNodes();
+        List<INode> pyNodes = PythonAggregator.getDetectedNodes();
+        List<INode> cNodes = CAggregator.getDetectedNodes();
+        LOG.info(
+                "ScannerManager: totals -> PY={} JAVA={} C={}",
+                pyNodes.size(),
+                javaNodes.size(),
+                cNodes.size());
         List<INode> nodes = new ArrayList<>();
-        nodes.addAll(JavaAggregator.getDetectedNodes());
-        nodes.addAll(PythonAggregator.getDetectedNodes());
-        nodes.addAll(CAggregator.getDetectedNodes());
+        nodes.addAll(javaNodes);
+        nodes.addAll(pyNodes);
+        nodes.addAll(cNodes);
         return nodes;
     }
 


### PR DESCRIPTION
## Summary
- log registration and check binding for Python rules
- trace Python visitor, detection engine, translation, and aggregation steps
- report per-language totals when generating CBOM

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c4d7447e083238026466910537f3b