### PR TITLE
Add execution logging for C/C++ analysis path

### DIFF
--- a/c/src/main/java/com/ibm/plugin/CAggregator.java
+++ b/c/src/main/java/com/ibm/plugin/CAggregator.java
@@ -8,11 +8,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class CAggregator implements IAggregator {
-    private static final Logger LOG = LoggerFactory.getLogger(CAggregator.class);
+    private static final Logger LOG = Loggers.get(CAggregator.class);
+    private static final String ORIGIN = CAggregator.class.getSimpleName() + ".java";
 
     private static ILanguageSupport<Object, Object, Object, Object> cLanguageSupport =
             LanguageSupporter.cLanguageSupporter();
@@ -22,10 +23,12 @@ public final class CAggregator implements IAggregator {
 
     public static void addNodes(@Nonnull List<INode> newNodes) {
         detectedNodes.addAll(newNodes);
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Aggregated {} nodes", newNodes.size());
-        }
         IAggregator.log(newNodes);
+        LOG.info(
+                "CXX {}: event=<aggregate> added={} total={}",
+                ORIGIN,
+                newNodes.size(),
+                detectedNodes.size());
     }
 
     @Nonnull

--- a/c/src/main/java/com/ibm/plugin/CCheckRegistrar.java
+++ b/c/src/main/java/com/ibm/plugin/CCheckRegistrar.java
@@ -1,11 +1,17 @@
 package com.ibm.plugin;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.plugins.cxx.CustomCxxRulesDefinition;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @SonarLintSide
 public final class CCheckRegistrar extends CustomCxxRulesDefinition {
+
+  private static final Logger LOG = Loggers.get(CCheckRegistrar.class);
+  private static final String ORIGIN = CCheckRegistrar.class.getSimpleName() + ".java";
 
   @Override
   public String repositoryName() {
@@ -21,6 +27,11 @@ public final class CCheckRegistrar extends CustomCxxRulesDefinition {
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public Class[] checkClasses() {
     List<Class<?>> checks = CRuleList.getChecks();
+    LOG.info(
+        "CXX {}: event=<register-checks> repoKey={} checks=[{}]",
+        ORIGIN,
+        CScannerRuleDefinition.REPOSITORY_KEY,
+        checks.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
     return checks.toArray(new Class[0]);
   }
 }

--- a/c/src/main/java/com/ibm/plugin/CRuleList.java
+++ b/c/src/main/java/com/ibm/plugin/CRuleList.java
@@ -2,12 +2,24 @@ package com.ibm.plugin;
 
 import com.ibm.plugin.rules.CInventoryRule;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class CRuleList {
     private CRuleList() {}
 
+    private static final Logger LOG = Loggers.get(CRuleList.class);
+    private static final String ORIGIN = CRuleList.class.getSimpleName() + ".java";
+
     public static @Nonnull List<Class<?>> getChecks() {
-        return List.of(CInventoryRule.class);
+        List<Class<?>> checks = List.of(CInventoryRule.class);
+        LOG.info(
+                "CXX {}: event=<rule-list> count={} checks=[{}]",
+                ORIGIN,
+                checks.size(),
+                checks.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
+        return checks;
     }
 }

--- a/c/src/main/java/com/ibm/plugin/CScannerRuleDefinition.java
+++ b/c/src/main/java/com/ibm/plugin/CScannerRuleDefinition.java
@@ -16,6 +16,7 @@ import org.sonar.plugins.cxx.CxxLanguage;
 public final class CScannerRuleDefinition implements RulesDefinition {
 
   private static final Logger LOG = Loggers.get(CScannerRuleDefinition.class);
+  private static final String ORIGIN = CScannerRuleDefinition.class.getSimpleName() + ".java";
 
   /** Keep public: CCheckRegistrar uses them */
   public static final String REPOSITORY_KEY  = "sonar-c-crypto";
@@ -46,9 +47,11 @@ public final class CScannerRuleDefinition implements RulesDefinition {
 
     repo.done();
 
-    LOG.info("Registered C repository '{}' with rules {}",
+    LOG.info(
+        "CXX {}: event=<repo-registered> repoKey={} rules=[{}]",
+        ORIGIN,
         REPOSITORY_KEY,
-        repo.rules().stream().map(NewRule::key).collect(Collectors.toList()));
+        repo.rules().stream().map(NewRule::key).collect(Collectors.joining(",")));
   }
 
   private static String readResource(String path) {

--- a/c/src/main/java/com/ibm/plugin/rules/CInventoryRule.java
+++ b/c/src/main/java/com/ibm/plugin/rules/CInventoryRule.java
@@ -3,6 +3,7 @@ package com.ibm.plugin.rules;
 import com.ibm.engine.detection.Finding;
 import com.ibm.engine.executive.DetectionExecutive;
 import com.ibm.engine.language.c.CxxScanContext;
+import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.mapper.model.INode;
 import com.ibm.plugin.CAggregator;
 import com.ibm.plugin.rules.detection.wolfcrypt.WolfCryptRules;
@@ -14,8 +15,8 @@ import com.sonar.cxx.sslr.api.AstNode;
 import com.sonar.cxx.sslr.api.GenericTokenType;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.check.Rule;
 import org.sonar.cxx.parser.CxxGrammarImpl;
 import org.sonar.cxx.parser.CxxPunctuator;
@@ -26,13 +27,18 @@ public class CInventoryRule extends SquidCheck<com.sonar.cxx.sslr.api.Grammar>
         implements IReportableDetectionRule<Object>,
                 com.ibm.common.IObserver<Finding<Object, Object, Object, Object>> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CInventoryRule.class);
+    private static final Logger LOG = Loggers.get(CInventoryRule.class);
+    private static final String ORIGIN = CInventoryRule.class.getSimpleName() + ".java";
 
     @Nonnull private final CxxTranslationProcess translationProcess = new CxxTranslationProcess();
 
     @Override
     public void init() {
         subscribeTo(CxxGrammarImpl.postfixExpression);
+        LOG.info(
+                "CXX {}: event=<visitor-init> ruleKey={} nodeKinds=[postfixExpression]",
+                ORIGIN,
+                "Inventory");
     }
 
     @Override
@@ -46,30 +52,58 @@ public class CInventoryRule extends SquidCheck<com.sonar.cxx.sslr.api.Grammar>
             return;
         }
         String callee = idNode.getTokenValue();
+        String filePath =
+                getContext().getInputFile() != null
+                        ? getContext().getInputFile().uri().getPath()
+                        : "<n/a>";
+        String line = idNode.getToken() != null ? String.valueOf(idNode.getToken().getLine()) : "<n/a>";
+        LOG.info(
+                "CXX {}: event=<visit-node> src={} callee={}",
+                ORIGIN,
+                filePath + ":" + line,
+                callee);
 
-        if (LOG.isTraceEnabled()) {
-            LOG.trace(
-                    "C CALL {} @ {}:{}",
-                    callee,
-                    getContext().getInputFile().filename(),
-                    idNode.getToken().getLine());
-        }
-
-        WolfCryptRules.rules()
-                .forEach(
-                        rule -> {
-                            DetectionExecutive<Object, Object, Object, Object> exec =
-                                    CAggregator.getLanguageSupport()
-                                            .createDetectionExecutive(
-                                                    node, rule, new CxxScanContext(getContext().getInputFile()));
-                            exec.subscribe(this);
-                            exec.start();
-                        });
+        List<IDetectionRule<Object>> rules = WolfCryptRules.rules();
+        LOG.info(
+                "CXX {}: event=<run-detection> src={} ruleCount={} callee={}",
+                ORIGIN,
+                filePath + ":" + line,
+                rules.size(),
+                callee);
+        rules.forEach(
+                rule -> {
+                    DetectionExecutive<Object, Object, Object, Object> exec =
+                            CAggregator.getLanguageSupport()
+                                    .createDetectionExecutive(
+                                            node, rule, new CxxScanContext(getContext().getInputFile()));
+                    exec.subscribe(this);
+                    exec.start();
+                });
         super.visitNode(node);
     }
 
     @Override
     public void update(@Nonnull Finding<Object, Object, Object, Object> finding) {
+        String filePath = finding.detectionStore().getScanContext().getFilePath();
+        String line = "<n/a>";
+        Object marker = finding.getMarkerTree();
+        if (marker instanceof AstNode ast) {
+            line = String.valueOf(ast.getToken().getLine());
+        }
+        String asset = finding.detectionStore().getDetectionRule().detectionValueContext().type().getSimpleName();
+        String alg =
+                finding
+                        .detectionStore()
+                        .getActionValue()
+                        .map(v -> v.asString())
+                        .orElse("<n/a>");
+        LOG.info(
+                "CXX {}: event=<finding> src={} asset={} alg={}",
+                ORIGIN,
+                filePath + ":" + line,
+                asset,
+                alg);
+
         List<INode> nodes = translationProcess.initiate(finding.detectionStore());
         CAggregator.addNodes(nodes);
         this.report(finding.getMarkerTree(), nodes)

--- a/c/src/main/java/com/ibm/plugin/translation/CxxTranslationProcess.java
+++ b/c/src/main/java/com/ibm/plugin/translation/CxxTranslationProcess.java
@@ -9,9 +9,13 @@ import com.ibm.mapper.reorganizer.IReorganizerRule;
 import com.ibm.plugin.translation.translator.CxxTranslator;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public final class CxxTranslationProcess
         extends ITranslationProcess<Object, Object, Object, Object> {
+    private static final Logger LOG = Loggers.get(CxxTranslationProcess.class);
+    private static final String ORIGIN = CxxTranslationProcess.class.getSimpleName() + ".java";
 
     public CxxTranslationProcess() {
         super(List.of());
@@ -21,11 +25,21 @@ public final class CxxTranslationProcess
     @Override
     public List<INode> initiate(
             @Nonnull DetectionStore<Object, Object, Object, Object> rootDetectionStore) {
+        LOG.info(
+                "CXX {}: event=<translate-start> findingId={}",
+                ORIGIN,
+                rootDetectionStore.getStoreId());
         CxxTranslator translator = new CxxTranslator();
         List<INode> translated = translator.translate(rootDetectionStore);
         Reorganizer reorganizer = new Reorganizer(reorganizerRules);
         List<INode> reorganized = reorganizer.reorganize(translated);
-        return Enricher.enrich(reorganized).stream().toList();
+        List<INode> result = Enricher.enrich(reorganized).stream().toList();
+        LOG.info(
+                "CXX {}: event=<translate-end> findingId={} nodes={}",
+                ORIGIN,
+                rootDetectionStore.getStoreId(),
+                result.size());
+        return result;
     }
 }
 

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageSupport.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageSupport.java
@@ -17,11 +17,12 @@ import com.sonar.cxx.sslr.api.GenericTokenType;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public class CxxLanguageSupport implements ILanguageSupport<Object, Object, Object, Object> {
-    private static final Logger LOG = LoggerFactory.getLogger(CxxLanguageSupport.class);
+    private static final Logger LOG = Loggers.get(CxxLanguageSupport.class);
+    private static final String ORIGIN = CxxLanguageSupport.class.getSimpleName() + ".java";
 
     @Nonnull private final Handler<Object, Object, Object, Object> handler;
 
@@ -71,6 +72,13 @@ public class CxxLanguageSupport implements ILanguageSupport<Object, Object, Obje
             AstNode idNode = node.getLastChild(GenericTokenType.IDENTIFIER);
             if (idNode != null) {
                 String name = idNode.getTokenValue();
+                String filePath = "<n/a>";
+                String line = idNode.getToken() != null ? String.valueOf(idNode.getToken().getLine()) : "<n/a>";
+                LOG.info(
+                        "CXX {}: event=<matcher> src={} callee={}",
+                        ORIGIN,
+                        filePath + ":" + line,
+                        name);
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("CXX matcher built for callee '{}'", name);
                 }

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
@@ -9,19 +9,28 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import com.sonar.cxx.sslr.api.AstNode;
 import com.sonar.cxx.sslr.api.GenericTokenType;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
+    private static final Logger LOG = Loggers.get(CxxLanguageTranslation.class);
+    private static final String ORIGIN = CxxLanguageTranslation.class.getSimpleName() + ".java";
     @Nonnull
     @Override
     public Optional<String> getMethodName(
             @Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
+        Optional<String> result = Optional.empty();
         if (methodInvocation instanceof AstNode node) {
             AstNode idNode = node.getLastChild(GenericTokenType.IDENTIFIER);
             if (idNode != null) {
-                return Optional.ofNullable(idNode.getTokenValue());
+                result = Optional.ofNullable(idNode.getTokenValue());
             }
         }
-        return Optional.empty();
+        LOG.info(
+                "CXX {}: event=<get-method-name> name={}",
+                ORIGIN,
+                result.orElse(""));
+        return result;
     }
 
     @Nonnull
@@ -40,28 +49,48 @@ public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
     @Nonnull
     @Override
     public List<IType> getMethodParameterTypes(@Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
-        return Collections.emptyList();
+        List<IType> result = Collections.emptyList();
+        LOG.info(
+                "CXX {}: event=<resolve> kind=param out={}",
+                ORIGIN,
+                result.size());
+        return result;
     }
 
     @Nonnull
     @Override
     public Optional<String> resolveIdentifierAsString(
             @Nonnull MatchContext matchContext, @Nonnull Object name) {
+        Optional<String> result = Optional.empty();
         if (name instanceof AstNode node) {
-            return Optional.ofNullable(node.getTokenValue());
+            result = Optional.ofNullable(node.getTokenValue());
         }
-        return Optional.empty();
+        LOG.info(
+                "CXX {}: event=<resolve> kind=value out={}",
+                ORIGIN,
+                result.orElse(""));
+        return result;
     }
 
     @Nonnull
     @Override
     public Optional<String> getEnumIdentifierName(@Nonnull MatchContext matchContext, @Nonnull Object enumIdentifier) {
-        return Optional.empty();
+        Optional<String> result = Optional.empty();
+        LOG.info(
+                "CXX {}: event=<resolve> kind=enum out={}",
+                ORIGIN,
+                "");
+        return result;
     }
 
     @Nonnull
     @Override
     public Optional<String> getEnumClassName(@Nonnull MatchContext matchContext, @Nonnull Object enumClass) {
-        return Optional.empty();
+        Optional<String> result = Optional.empty();
+        LOG.info(
+                "CXX {}: event=<resolve> kind=enum out={}",
+                ORIGIN,
+                "");
+        return result;
     }
 }

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/CryptographyPlugin.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/CryptographyPlugin.java
@@ -19,8 +19,8 @@
  */
 package com.ibm.plugin;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.SonarRuntime;
@@ -30,14 +30,18 @@ import com.ibm.plugin.CScannerRuleDefinition;
 public class CryptographyPlugin implements Plugin {
 
     @SuppressWarnings({"java:S1874"})
-    private static final Logger LOGGER = LoggerFactory.getLogger(CryptographyPlugin.class);
+    private static final Logger LOG = Loggers.get(CryptographyPlugin.class);
+    private static final String ORIGIN = CryptographyPlugin.class.getSimpleName() + ".java";
 
     @Override
     public void define(Context context) {
         SonarRuntime runtime = context.getRuntime();
         SonarProduct product = runtime.getProduct();
 
-        LOGGER.info("Sonar Cryptography initialized in context (" + product + ")");
+        LOG.info(
+                "CXX {}: event=<bootstrap> product={}",
+                ORIGIN,
+                product);
 
         context.addExtensions(Configuration.getPropertyDefinitions()); // add configuration
         context.addExtensions(

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
@@ -33,6 +33,7 @@ import org.sonar.api.utils.log.Loggers;
 
 public class OutputFileJob implements PostJob {
     private static final Logger LOG = Loggers.get(OutputFileJob.class);
+    private static final String ORIGIN = OutputFileJob.class.getSimpleName() + ".java";
 
     @Override
     public void describe(PostJobDescriptor postJobDescriptor) {
@@ -47,14 +48,15 @@ public class OutputFileJob implements PostJob {
                         .get(Constants.CBOM_OUTPUT_NAME)
                         .orElse(Constants.CBOM_OUTPUT_NAME_DEFAULT);
         ScannerManager scannerManager = new ScannerManager(new CBOMOutputFileFactory());
-        LOG.info(
-                "CBOM write: PY={} JAVA={} C={}",
-                PythonAggregator.getDetectedNodes().size(),
-                JavaAggregator.getDetectedNodes().size(),
-                CAggregator.getDetectedNodes().size());
         final File cbom = new File(cbomFilename + ".json");
         scannerManager.getOutputFile().saveTo(cbom);
-        LOG.info("CBOM was successfully generated '{}'.", cbom.getAbsolutePath());
+        LOG.info(
+                "CXX {}: event=<cbom-write> path={} JAVA={} PY={} C={}",
+                ORIGIN,
+                cbom.getAbsolutePath(),
+                JavaAggregator.getDetectedNodes().size(),
+                PythonAggregator.getDetectedNodes().size(),
+                CAggregator.getDetectedNodes().size());
         scannerManager.getStatistics().print(LOG::info);
         scannerManager.reset();
     }

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/ScannerManager.java
@@ -40,6 +40,7 @@ public final class ScannerManager {
     private final IOutputFileFactory outputFileFactory;
 
     private static final Logger LOG = Loggers.get(ScannerManager.class);
+    private static final String ORIGIN = ScannerManager.class.getSimpleName() + ".java";
 
     public ScannerManager(@Nullable IOutputFileFactory outputFileFactory) {
         this.outputFileFactory = outputFileFactory;
@@ -73,9 +74,10 @@ public final class ScannerManager {
         List<INode> pyNodes = PythonAggregator.getDetectedNodes();
         List<INode> cNodes = CAggregator.getDetectedNodes();
         LOG.info(
-                "ScannerManager: totals -> PY={} JAVA={} C={}",
-                pyNodes.size(),
+                "CXX {}: event=<totals> JAVA={} PY={} C={}",
+                ORIGIN,
                 javaNodes.size(),
+                pyNodes.size(),
                 cNodes.size());
         List<INode> nodes = new ArrayList<>();
         nodes.addAll(javaNodes);


### PR DESCRIPTION
## Summary
- add INFO logs to C/C++ plugin bootstrap, rule registration, visitor, detection engine, translation and aggregation
- track CBOM write and scan totals with origin metadata

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c5b40001083238a301ad6dc857bd3