### PR TITLE
Ensure lambda captures only final variables

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
@@ -40,19 +40,19 @@ public class CxxDetectionEngine implements IDetectionEngine<Object, Object> {
 
     @Override
     public void run(@Nonnull TraceSymbol<Object> traceSymbol, @Nonnull Object tree) {
-        String filePath = detectionStore.getScanContext().getFilePath();
-        String line = "<n/a>";
-        String nodeKind = "<n/a>";
-        if (tree instanceof AstNode node) {
-            line = node.getToken() != null ? String.valueOf(node.getToken().getLine()) : "<n/a>";
-            nodeKind = node.getType().toString();
-        }
+        AstNode node = tree instanceof AstNode ? (AstNode) tree : null;
+        final String filePath = detectionStore.getScanContext().getFilePath();
+        final String line =
+                node != null && node.getToken() != null
+                        ? String.valueOf(node.getToken().getLine())
+                        : "<n/a>";
+        final String nodeKind = node != null ? node.getType().toString() : "<n/a>";
         LOG.info(
                 "CXX {}: event=<engine-run> src={} nodeKind={}",
                 ORIGIN,
                 filePath + ":" + line,
                 nodeKind);
-        if (tree instanceof AstNode node) {
+        if (node != null) {
             if (node.getFirstChild(CxxPunctuator.BR_LEFT) != null) {
                 handler.addCallToCallStack(node, detectionStore.getScanContext());
                 if (detectionStore


### PR DESCRIPTION
## Summary
- Rework `CxxDetectionEngine.run` variable initialization so `filePath`, `line`, and `nodeKind` are final before use in a lambda
- Prevent lambda compilation errors by handling `AstNode` lookup and logging safely

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.junit:junit-bom, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c5e1930308323a6fd57b19c773ed1